### PR TITLE
.env を使用しないように修正

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,0 @@
-CIRCLECI_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: cargo
 
 env:
   global:
-    - PROJECT_NAME=circleci-checker
+    - PROJECT_NAME=circleci_checker
 
 script: cargo test -- --test-threads=1
 
@@ -28,8 +28,6 @@ matrix:
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
 
-before_script:
-  - cp .env.sample .env
 addons:
   apt:
     packages:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
 extern crate circleci_checker;
 extern crate rustc_serialize;
-extern crate dotenv;
 
 use std::error::Error;
 
 fn main() {
-    dotenv::dotenv().expect("Failed to read .env file");
     match print_projects() {
         Ok(()) => return,
         Err(ref error) => println!("{}", error.description()),

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,3 @@
-extern crate dotenv;
-
 use hyper::Client;
 use hyper::net::HttpsConnector;
 use hyper_native_tls::NativeTlsClient;
@@ -50,7 +48,7 @@ mod tests {
 
     #[test]
     fn valid_json_response() {
-        dotenv::dotenv().expect("Failed to read .env file");
+        env::set_var("CIRCLECI_TOKEN", "xxxxxx");
         let token = env::var("CIRCLECI_TOKEN").unwrap();
 
         let json = r#"
@@ -97,7 +95,7 @@ mod tests {
 
     #[test]
     fn invalid_json_response() {
-        dotenv::dotenv().expect("Failed to read .env file");
+        env::set_var("CIRCLECI_TOKEN", "xxxxxx");
         let token = env::var("CIRCLECI_TOKEN").unwrap();
         let json = r#"
         
@@ -133,7 +131,7 @@ mod tests {
 
     #[test]
     fn connection_error() {
-        dotenv::dotenv().expect("Failed to read .env file");
+        env::set_var("CIRCLECI_TOKEN", "xxxxxx");
         let projects = fetch_projects();
         assert!(projects.is_err());
         assert_eq!(projects.err().unwrap().description(), "connection refused");


### PR DESCRIPTION
実行する際、.env ファイルは使用せず
```
CIRCLECI_TOKEN=xxxxx /path/to/circleci-checker
```
とするように変更